### PR TITLE
Fix PROGRAM_NAME mistype

### DIFF
--- a/yasmate.rb
+++ b/yasmate.rb
@@ -259,7 +259,7 @@ class TmSnippet
     doc << (self.type || "")
     doc << "# uuid: #{self.uuid}\n"
     doc << "# key: #{self.key}\n" if self.key
-    doc << "# contributor: Translated from textmate snippet by PROGRAM_NAME\n"
+    doc << "# contributor: Translated from textmate snippet by #{File.basename($PROGRAM_NAME)}\n"
     doc << "# name: #{self.name}\n"
     doc << (self.binding || "")
     doc << (self.condition || "")


### PR DESCRIPTION
Hi,

There was a missing '$' for PROGRAM_NAME. 

I added a File.basename call to make the output prettier. You can maybe also want .chomp(".rb").
